### PR TITLE
Fix link to University of Leicester Study Skills

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ These intentions must be reflected in the contributions that we make to the proj
 In addition to the CoC, we encourage intentional, inclusive actions from contributors to _The Turing Way_.
 Here are a few examples of such actions:
 
-- use respectful, gender-neutral and inclusive language (learn more about [inclusive writing](https://www.le.ac.uk/oerresources/ssds/studyskills/page_37.htm), resource by University of Leicester).
+- use respectful, gender-neutral and inclusive language (learn more about inclusive writing on page 22 of [University of Leicester Study Skills pdf](https://www2.le.ac.uk/projects/oer/oers/ssds/oers/study-skills/studyskills.pdf), also available as a [zipped html](https://www2.le.ac.uk/projects/oer/oers/ssds/oers/study-skills/studyskills_HTML.zip)).
 - aim to include perspectives of researchers from different research backgrounds such as science, humanities and social sciences by not limiting the scope to only scientific domains.
 - make sure that the colour palettes are accessible to colour-blind readers and contributors.
 See the blogpost [Designing Scientific Figures for Colour Blindness](https://www.lewismackenzie.science/blog-1/2017/2/9/designing-scientific-figures-for-colour-blindness) for an example of how somebody improved one of their diagrams, including links to recommended colour palettes and a colour-blindness simulator.


### PR DESCRIPTION
<!--
Please complete the following sections when you submit your pull request. You are encouraged to keep this top level comment box updated as you develop and respond to reviews. Note that text within html comment tags will not be rendered.
-->
### Summary

<!-- Describe the problem you're trying to fix in this pull request. Please reference any related issue and use fixes/close to automatically close them, if pertinent. For example: "Fixes #58", or "Addresses (but does not close) #238". -->

Fixes #1865

*Replaces broken link to Leicester Study Skills PDF.*

### List of changes proposed in this PR (pull-request)

<!-- We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

* *Fixed link.*
* *Add alternate link for zipped html option.*
* *Slightly rephrased copy to cover both options.*


### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

- [x] *Double check the links.*
- [x] Make sure the rephrasing is ok.


### Acknowledging contributors

<!-- Please select the correct box -->

- [X] The following people should be added to the [table of contributors](https://github.com/alan-turing-institute/the-turing-way/blob/master/README.md#contributors) in the README file: griff-rees
